### PR TITLE
Add Product::getOptionsBySku()

### DIFF
--- a/src/Api/Products.php
+++ b/src/Api/Products.php
@@ -146,4 +146,12 @@ class Products extends AbstractApi
 
         return $this->put('/products/'.$sku, $data);
     }
+
+    /**
+     * Get full product option data for the given sku
+     */
+    public function getOptionsBySku(string $sku): Response
+    {
+        return $this->get('/products/' . $sku . '/options');
+    }
 }


### PR DESCRIPTION
Added method to get full Product Options (including dependency data) from the `/products/{sku}/options` endpoint