### PR TITLE
Add ProductAttributes::getAttributesWithLookupValues()

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,6 +374,30 @@ Retrieve specific product attribute information:
 Magento::api('productAttributes')->show($attributeCode);
 ```
 
+`/V1/products/attributes`
+
+Fetches all Product attributes specified by `$attribute_ids`.
+`$attribute_ids` is optional and can be an array or a string (or null).
+```php
+Magento::api('productAttributes')->getByAttributeId($attribute_ids = null);
+```
+
+`/V1/products/attributes`
+
+Fetches all Product attributes specified by `$attribute_codes`.
+`$attribute_codes` is optional and can be an array or a string (or null).
+```php
+Magento::api('productAttributes')->getByAttributeCode($attribute_codes = null);
+```
+
+`/V1/products/attributes`
+
+Fetches all Product Custom Attributes with lookup values (i.e., attributes with `frontend_input` = `boolean` or `select`
+or `multiselect`).
+```php
+Magento::api('productAttributes')->getAttributesWithLookupValues();
+```
+
 <a id="product-link-types"></a>
 ### Product Link Types (catalogProductLinkTypeListV1)
 

--- a/src/Api/ProductAttributes.php
+++ b/src/Api/ProductAttributes.php
@@ -37,7 +37,7 @@ class ProductAttributes extends AbstractApi
      * $attribute_ids is optional and can be an array or a string (or null).
      * Believe it or don't, specifying the return type causes an exception.
      *
-     * @param string|array|null $attribute_codes
+     * @param string|array|null $attribute_ids
      * @return \Illuminate\Http\Client\Response
      * @throws \Exception
      */
@@ -68,10 +68,9 @@ class ProductAttributes extends AbstractApi
         return $this->get('/products/attributes', $filters);
     }
 
-
     /**
      * Fetches all Product attributes specified by $attribute_codes.
-     * $attribute_code is optional and can be an array or a string (or null).
+     * $attribute_codes is optional and can be an array or a string (or null).
      * Believe it or don't, specifying the return type causes an exception.
      *
      * @param string|array|null $attribute_codes
@@ -106,7 +105,8 @@ class ProductAttributes extends AbstractApi
     }
 
     /**
-     * Fetches all Product Custom Attributes with lookup values (frontend_input boolean, select, and multiselect)
+     * Fetches all Product Custom Attributes with lookup values.
+     * I.e., attributes with frontend_input = boolean|select|multiselect.
      * @return \Illuminate\Http\Client\Response
      * @throws \Exception
      */

--- a/src/Api/ProductAttributes.php
+++ b/src/Api/ProductAttributes.php
@@ -104,4 +104,36 @@ class ProductAttributes extends AbstractApi
         }
         return $this->get('/products/attributes', $filters);
     }
+
+    /**
+     * Fetches all Product Custom Attributes with lookup values (frontend_input boolean, select, and multiselect)
+     * @return \Illuminate\Http\Client\Response
+     * @throws \Exception
+     */
+    public function getAttributesWithLookupValues()
+    {
+        $filters = [
+            'searchCriteria' => [
+                'filter_groups' => [
+                    [
+                        'filters' => [
+                            [
+                                'field' => 'frontend_input',
+                                'condition_type' => 'in',
+                                'value' => 'boolean,select,multiselect',
+                            ],
+                        ],
+                    ],
+                ],
+                'sortOrders' => [
+                    [
+                        'field' => 'attribute_code',
+                        'direction' => 'ASC',
+                    ],
+                ],
+            ],
+            'fields' => 'items[attribute_code,options]',
+        ];
+        return $this->get('/products/attributes', $filters);
+    }
 }


### PR DESCRIPTION
Fetches ProductAttributes which have lookup values and the lookup values.

Manually tested locally against McStagin' without issues.
Once this is merged I'll create a new tag and update Cobain's `composer.json` in the next M2 integration ticket I'm working, OUT-859.