### PR TITLE
Hotfix/out 948 resolve breaking changes

### DIFF
--- a/config/magento.php
+++ b/config/magento.php
@@ -72,4 +72,14 @@ return [
     |  Laravel Log file.
     */
     'log_failed_requests' => env('MAGENTO_API_LOG_FAILED_REQUESTS', false),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Magento API Website ID
+    |--------------------------------------------------------------------------
+    |
+    |  Default website_id value to use with customer requests, et al.
+    |
+    */
+    'website_id' => env('MAGENTO_API_WEBSITE_ID', 1),
 ];

--- a/src/Api/AbstractApi.php
+++ b/src/Api/AbstractApi.php
@@ -13,6 +13,12 @@ use Interiordefine\Magento\Magento;
 abstract class AbstractApi
 {
 
+    /**
+     * This is not in the original package.
+     * At present, the value should be 1 for almost all ID purposes because we only have the one store.
+     * This seems like it should be a config, though, rather than a class constant.
+     * Per response from `/rest/default/V1/store/websites`, website_id 0 is Magento admin, 1 is storefront.
+     */
     const WEBSITE_ID = 1;
 
     /**

--- a/src/Api/Customers.php
+++ b/src/Api/Customers.php
@@ -16,7 +16,7 @@ class Customers extends AbstractApi
      * @return Response
      * @throws Exception
      */
-    public function all(array $filters = [], int $pageSize = 50, int $currentPage = 1): Response
+    public function all(int $pageSize = 50, int $currentPage = 1, array $filters = []): Response
     {
         return $this->get('/customers/search', array_merge($filters, [
             'searchCriteria[pageSize]'    => $pageSize,
@@ -47,17 +47,32 @@ class Customers extends AbstractApi
     /**
      * Create customer account. Perform necessary business operations like sending email.
      *
+     * @param array $body
+     * @return Response
+     * @throws Exception
+     */
+    public function create(array $body): Response
+    {
+        return $this->post('/customers', $body);
+    }
+
+    /**
+     * Create customer account on storefront. Perform necessary business operations like sending email.
+     *
      * @param array $customer
      * @param string|null $password
      * @return Response
      * @throws Exception
      */
-    public function create(array $customer, string $password = null): Response
+    public function idCreate(array $customer, string $password = null): Response
     {
-        return $this->post('/customers', [
-            'customer' => array_merge($customer, [
-                'website_id' => self::WEBSITE_ID,
-            ]),
+        /**
+         * Added config for website_id.
+         * This also allows specifying a different website.
+         */
+        $customer['website_id'] = !empty($customer['website_id']) ? $customer['website_id'] : config('magento.website_id');
+        return $this->create([
+            'customer' => $customer,
             'password' => $password,
         ]);
     }
@@ -139,15 +154,16 @@ class Customers extends AbstractApi
     {
         return $this->post('/customers/isEmailAvailable', [
             'customerEmail' => $email,
-            'websiteId' => self::WEBSITE_ID,
+            'websiteId' => config('magento.website_id'),
         ]);
     }
 
     /**
      * Get customer id by email address.
      *
-     * @param  string  $email
-     * @return object
+     * @param string $email
+     * @return Response
+     * @throws Exception
      */
     public function getCustomerID(string $email): Response
     {
@@ -161,24 +177,26 @@ class Customers extends AbstractApi
     /**
      * Update customer by customer ID.
      *
-     * @param  int  $customerID
-     * @param  array  $customerGroupUpdateBody
-     * @return array
+     * @param int $customerID
+     * @param int $customerGroupID
+     * @return Response
+     * @throws Exception
      */
-    public function updateCustomerByID(int $customerID, int $CustomerGroupID): Response
+    public function updateCustomerByID(int $customerID, int $customerGroupID): Response
     {
         return $this->put('/customers/' . $customerID, [
             'customer' => [
-                'group_id' => $CustomerGroupID
+                'group_id' => $customerGroupID,
             ]
         ]);
     }
 
-     /**
+    /**
      * Update customer Subscription with customer ID.
      *
-     * @param  int  $customerID
-     * @return array
+     * @param int $customerID
+     * @return Response
+     * @throws Exception
      */
     public function updateCustomerSubscription(int $customerID): Response
     {
@@ -194,8 +212,9 @@ class Customers extends AbstractApi
     /**
      * Unsubscribe customer via email if it exists.
      *
-     * @param  string  $email
-     * @return array
+     * @param string $email
+     * @return Response|string
+     * @throws Exception
      */
     public function unsubscribe(string $email)
     {

--- a/src/Api/Orders.php
+++ b/src/Api/Orders.php
@@ -10,18 +10,38 @@ class Orders extends AbstractApi
     /**
      * Lists orders that match specified search criteria.
      *
-     * @param array $filters
      * @param int $pageSize
      * @param int $currentPage
+     * @param array $filters
      * @return Response
      * @throws Exception
      */
-    public function all(array $filters = [], int $pageSize = 50, int $currentPage = 1): Response
+    public function all(int $pageSize = 50, int $currentPage = 1, array $filters = []): Response
     {
         return $this->get('/orders', array_merge($filters, [
             'searchCriteria[pageSize]'    => $pageSize,
             'searchCriteria[currentPage]' => $currentPage,
         ]));
+    }
+
+    /**
+     * Fetches Orders created since $dateTime
+     *
+     * @param string $dateTime
+     * @param int $pageSize
+     * @param int $currentPage
+     * @return Response
+     * @throws Exception
+     */
+    public function getSince(string $dateTime, int $pageSize = 50, int $currentPage = 1): Response
+    {
+        $filter= [
+            'searchCriteria[filterGroups][0][filters][0][conditionType]' => 'from',
+            'searchCriteria[filterGroups][0][filters][0][field]' => 'created_at',
+            'searchCriteria[filterGroups][0][filters][0][value]' => $dateTime,
+        ];
+
+        return $this->all($pageSize, $currentPage, $filter);
     }
 
     /**
@@ -80,10 +100,11 @@ class Orders extends AbstractApi
     /**
      * Loads a specified order.
      *
-     * @param  string $incrementId
-     * @return array
+     * @param string $incrementId
+     * @return Response|array
+     * @throws Exception
      */
-    public function showByIncrementId($incrementId) {
+    public function showByIncrementId(string $incrementId) {
 
         $query = array('searchCriteria' => []);
         $query['searchCriteria']['filter_groups'] = array('0'=> []);
@@ -94,7 +115,7 @@ class Orders extends AbstractApi
                 'value' => $incrementId,
                 'condition_type' => 'eq'
             );
-#        $result = $this->get('/orders',urldecode(http_build_query($query)));
+
         $result = $this->get('/orders',$query);
         $items = $result->json();
         if (isset($items['items'])) {

--- a/src/Api/ProductAttributes.php
+++ b/src/Api/ProductAttributes.php
@@ -2,6 +2,7 @@
 
 namespace Interiordefine\Magento\Api;
 
+use Exception;
 use Illuminate\Http\Client\Response;
 
 class ProductAttributes extends AbstractApi
@@ -9,10 +10,11 @@ class ProductAttributes extends AbstractApi
     /**
      * Retrieve specific product attribute information.
      *
-     * @param  string  $attribute
-     * @return array
+     * @param string $attribute
+     * @return Response
+     * @throws Exception
      */
-    public function show($attribute)
+    public function show(string $attribute): Response
     {
         return $this->get('/products/attributes/'.$attribute);
     }
@@ -20,11 +22,12 @@ class ProductAttributes extends AbstractApi
     /**
      * The list of Product Attributes.
      *
-     * @param  int  $pageSize
-     * @param  int  $currentPage
-     * @return array
+     * @param int $pageSize
+     * @param int $currentPage
+     * @return Response
+     * @throws Exception
      */
-    public function all($pageSize = 50, $currentPage = 1)
+    public function all(int $pageSize = 50, int $currentPage = 1): Response
     {
         return $this->get('/products/attributes', [
             'searchCriteria[pageSize]'    => $pageSize,
@@ -35,13 +38,12 @@ class ProductAttributes extends AbstractApi
     /**
      * Fetches all Product attributes specified by $attribute_ids.
      * $attribute_ids is optional and can be an array or a string (or null).
-     * Believe it or don't, specifying the return type causes an exception.
      *
      * @param string|array|null $attribute_ids
-     * @return \Illuminate\Http\Client\Response
-     * @throws \Exception
+     * @return Response
+     * @throws Exception
      */
-    public function getByAttributeId($attribute_ids = null)
+    public function getByAttributeId($attribute_ids = null): Response
     {
         $filters = [];
         if (!empty($attribute_ids)) {
@@ -74,10 +76,10 @@ class ProductAttributes extends AbstractApi
      * Believe it or don't, specifying the return type causes an exception.
      *
      * @param string|array|null $attribute_codes
-     * @return \Illuminate\Http\Client\Response
-     * @throws \Exception
+     * @return Response
+     * @throws Exception
      */
-    public function getByAttributeCode($attribute_codes = null)
+    public function getByAttributeCode($attribute_codes = null): Response
     {
         $filters = [];
         if (!empty($attribute_codes)) {
@@ -107,10 +109,10 @@ class ProductAttributes extends AbstractApi
     /**
      * Fetches all Product Custom Attributes with lookup values.
      * I.e., attributes with frontend_input = boolean|select|multiselect.
-     * @return \Illuminate\Http\Client\Response
-     * @throws \Exception
+     * @return Response
+     * @throws Exception
      */
-    public function getAttributesWithLookupValues()
+    public function getAttributesWithLookupValues(): Response
     {
         $filters = [
             'searchCriteria' => [

--- a/src/Api/Products.php
+++ b/src/Api/Products.php
@@ -12,17 +12,17 @@ class Products extends AbstractApi
      *
      * https://magento.redoc.ly/2.4.3-admin/tag/products#operation/catalogProductRepositoryV1SavePost
      *
-     * @param array $filters
      * @param int|null $pageSize
      * @param int $currentPage
+     * @param array $filters
      * @return Response
      * @throws Exception
      */
-    public function all(array $filters = [], int $pageSize = null, int $currentPage = 1): Response
+    public function all(int $pageSize = 50, int $currentPage = 1, array $filters = []): Response
     {
         /**
-         * Arguably, the filters we pass should supercede the pageSize and currentPage values.
-         * In any case, this package has a significant limitation but we may not care about it.
+         * Arguably, the filters we pass should supersede the pageSize and currentPage values.
+         * In any case, this package has a significant limitation, but we may not care about it.
          * The fact that it treats query string arguments as a flat array is problematic because the package uses
          * array_merge() to apply "filters" even though many entities (filterGroups, filters, sort groups, et al), are
          * numerically indexed in the query string arguments.
@@ -104,19 +104,32 @@ class Products extends AbstractApi
      * @return Response
      * @throws Exception
      */
-    public function getBySku(string $sku): Response
+    public function show(string $sku): Response
     {
         return $this->get('/products/'.$sku);
+    }
+
+    /**
+     * Make redundant wrapper functions instead of renaming functions from the original package.
+     *
+     * @param string $sku
+     * @return Response
+     * @throws Exception
+     */
+    public function getBySku(string $sku): Response
+    {
+        return $this->show($sku);
     }
 
 
     /**
      * Get info about product by product ID.
      *
-     * @param  int  $id
-     * @return array
+     * @param int $id
+     * @return Response|array
+     * @throws Exception
      */
-    public function getById($id)
+    public function getById(int $id)
     {
         $query = array('searchCriteria' => []);
         $query['searchCriteria']['filter_groups'] = array('0'=> []);


### PR DESCRIPTION
I used the wrong ticket number in the branch name.
https://interiordefine.atlassian.net/browse/OUT-942

This PR reverts all breaking changes that are incompatible with the original package from Grayloon and thus allow us to use updates from the vendor.

All tests from the vendor currently pass again.

## Changes

### config/magento.php
* add `website_id` config (defaults to `1`) to replace class constant `AbstractApi::WEBSITE_ID`

### src/Api/AbstractApi.php
* add comments about class constant `AbstractApi::WEBSITE_ID`

### src/Api/Customers.php
* revert changes to argument order of `all()`
* revert changes to `create()`
* add `idCreate()` to retain the utility provided by the modified version of `create()`
* use `config('magento.website_id')` where `AbstractApi::WEBSITE_ID` was previously used
* PHP CS fixes

### src/Api/Orders.php
* revert changes to argument order of `all()`
* add `getSince()` to allow fetching Orders created since the given dateTime string
  * this is how the `all()` is used in Cobain `app/Console/Commands/PullOrders.php`
* PHP CS fixes

### src/Api/ProductAttributes.php
* PHP CS fixes

### src/Api/Products.php
* revert changes to argument order of `all()`
* restore `show()`
* add `getBySku()` as helper/wrapper for `show()`
* PHP CS fixes