### PR TITLE
Hotfix/nojira update test matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,10 +25,13 @@ jobs:
               experimental: true
             - php: 8.0
               laravel: ^9.0
+              experimental: false
             - php: 8.1
               laravel: ^8.0
+              experimental: false
             - php: 8.1
               laravel: ^9.0
+              experimental: false
 
     continue-on-error: ${{ matrix.experimental }}
     name: PHP v${{ matrix.php }} - Laravel v${{ matrix.laravel }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,9 +16,15 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [7.3, 7.4, 8.0, 8.1]
-        laravel: [^7.0, ^8.0, ^9.0]
+        php: [7.4, 8.0, 8.1]
+        laravel: [^7.0, ^8.0]
+        experimental: [false]
+        include:
+            - php: 8.1
+              laravel: ^9.0
+              experimental: true
 
+    continue-on-error: ${{ matrix.experimental }}
     name: PHP v${{ matrix.php }} - Laravel v${{ matrix.laravel }}
 
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,9 +23,12 @@ jobs:
             - php: 8.1
               laravel: ^8.0
               experimental: false
-            - php: 8.0
+            - php: 7.4
               laravel: ^9.0
               experimental: true
+            - php: 8.0
+              laravel: ^9.0
+              experimental: false
             - php: 8.1
               laravel: ^9.0
               experimental: false

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,9 +20,6 @@ jobs:
         laravel: [^7.0, ^8.0]
         experimental: [false]
         include:
-            - php: 7.4
-              laravel: ^9.0
-              experimental: true
             - php: 8.0
               laravel: ^9.0
               experimental: false

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,18 +20,15 @@ jobs:
         laravel: [^7.0, ^8.0]
         experimental: [false]
         include:
-            - php: 8.1
-              laravel: ^8.0
-              experimental: false
             - php: 7.4
               laravel: ^9.0
               experimental: true
             - php: 8.0
               laravel: ^9.0
-              experimental: false
+            - php: 8.1
+              laravel: ^8.0
             - php: 8.1
               laravel: ^9.0
-              experimental: false
 
     continue-on-error: ${{ matrix.experimental }}
     name: PHP v${{ matrix.php }} - Laravel v${{ matrix.laravel }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,13 +16,19 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [7.4, 8.0, 8.1]
+        php: [7.4, 8.0]
         laravel: [^7.0, ^8.0]
         experimental: [false]
         include:
             - php: 8.1
+              laravel: ^8.0
+              experimental: false
+            - php: 8.0
               laravel: ^9.0
               experimental: true
+            - php: 8.1
+              laravel: ^9.0
+              experimental: false
 
     continue-on-error: ${{ matrix.experimental }}
     name: PHP v${{ matrix.php }} - Laravel v${{ matrix.laravel }}


### PR DESCRIPTION
This PR removes unsupported combinations of PHP and Laravel versions from the Github test matrix.
Unsupported includes PHP 7.3 with all versions of Laravel because PHP 7.3 is past EOL.

The `experimental` key was added to the test matrix to allow unsupported combinations to fail without causing all other tests to fail.
It is no longer needed because unsupported combinations have been removed, but I kept it for now to help me remember that it is available if needed.