### PR TITLE
Add API method to create a media gallery entry for a Product

### DIFF
--- a/src/Api/Products.php
+++ b/src/Api/Products.php
@@ -236,4 +236,17 @@ class Products extends AbstractApi
     {
         return $this->post('/products', $array);
     }
+
+    /**
+     * Add a media gallery entry for the product specified by $sku.
+     *
+     * @param string $sku
+     * @param array $payload
+     * @return Response
+     * @throws Exception
+     */
+    public function addMedia(string $sku, array $payload): Response
+    {
+        return $this->post('/products/' . $sku . '/media', $payload);
+    }
 }


### PR DESCRIPTION
Add the method `addMedia(string $sku, array $payload)` to Products.
This method is required to be able to create quickship products with images in M2.